### PR TITLE
Support for multiple mirror feeds

### DIFF
--- a/src/BaGetter.Core/Configuration/MirrorOptions.cs
+++ b/src/BaGetter.Core/Configuration/MirrorOptions.cs
@@ -32,7 +32,8 @@ public class MirrorOptions : IValidatableObject
     /// <summary>
     /// Whether or not the package source is a v2 package source feed.
     /// </summary>
-    public bool Legacy {
+    public bool Legacy
+    {
         get => _legacy;
         set
         {

--- a/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -7,6 +8,7 @@ using BaGetter.Protocol;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace BaGetter.Core;
@@ -86,6 +88,7 @@ public static partial class DependencyInjectionExtensions
 
         services.TryAddSingleton(HttpClientFactory);
         services.TryAddSingleton(NuGetClientFactoryFactory);
+        services.TryAddSingleton(CreateUpstreamClients);
 
         services.TryAddScoped<DownloadsImporter>();
 
@@ -106,6 +109,7 @@ public static partial class DependencyInjectionExtensions
         services.TryAddTransient<PackageService>();
         services.TryAddTransient<V2UpstreamClient>();
         services.TryAddTransient<V3UpstreamClient>();
+        services.TryAddTransient<MultiFeedUpstreamClient>();
         services.TryAddTransient<DisabledUpstreamClient>();
         services.TryAddSingleton<NullStorageService>();
         services.TryAddTransient<PackageDatabase>();
@@ -188,6 +192,37 @@ public static partial class DependencyInjectionExtensions
         return client;
     }
 
+    private static List<IUpstreamClient> CreateUpstreamClients(IServiceProvider provider)
+    {
+        var options = provider.GetRequiredService<IOptions<MirrorOptions>>().Value;
+        var httpClient = provider.GetRequiredService<HttpClient>();
+
+        var clients = new List<IUpstreamClient>();
+
+        foreach (var source in options.Sources)
+        {
+            IUpstreamClient client;
+
+            if (source.Legacy)
+            {
+                var logger = provider.GetRequiredService<ILogger<V2UpstreamClient>>();
+                var optionSnapshot = (IOptionsSnapshot<MirrorOptions>)provider.GetRequiredService<IOptions<MirrorOptions>>();
+                client = new V2UpstreamClient(optionSnapshot, logger);
+            }
+            else
+            {
+                var logger = provider.GetRequiredService<ILogger<V3UpstreamClient>>();
+                var nugetClientFactory = new NuGetClientFactory(httpClient, source.PackageSource.ToString());
+
+                client = new V3UpstreamClient(new NuGetClient(nugetClientFactory), logger);
+            }
+
+            clients.Add(client);
+        }
+
+        return clients;
+    }
+
     private static NuGetClientFactory NuGetClientFactoryFactory(IServiceProvider provider)
     {
         var httpClient = provider.GetRequiredService<HttpClient>();
@@ -202,11 +237,16 @@ public static partial class DependencyInjectionExtensions
     {
         var options = provider.GetRequiredService<IOptionsSnapshot<MirrorOptions>>();
 
-        return options.Value.Enabled switch
+        if (!options.Value.Enabled)
+            return provider.GetRequiredService<DisabledUpstreamClient>();
+
+        if (options.Value.HasMultipleSources)
         {
-            false => provider.GetRequiredService<DisabledUpstreamClient>(),
-            true when options.Value.Legacy => provider.GetRequiredService<V2UpstreamClient>(),
-            _ => provider.GetRequiredService<V3UpstreamClient>()
-        };
+            return provider.GetRequiredService<MultiFeedUpstreamClient>();
+        }
+        else
+        {
+            return options.Value.Legacy ? provider.GetRequiredService<V2UpstreamClient>() : provider.GetRequiredService<V3UpstreamClient>();
+        }
     }
 }

--- a/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
@@ -203,11 +203,10 @@ public static partial class DependencyInjectionExtensions
 
             if (source.Legacy)
             {
-                var logger = provider.GetRequiredService<ILogger<V2UpstreamClient>>();
-
                 using var scope = provider.CreateScope();
                 var scopedProvider = scope.ServiceProvider;
 
+                var logger = scopedProvider.GetRequiredService<ILogger<V2UpstreamClient>>();
                 var optionSnapshot = scopedProvider.GetRequiredService<IOptionsSnapshot<MirrorOptions>>();
                 client = new V2UpstreamClient(optionSnapshot, logger);
             }

--- a/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -107,8 +108,6 @@ public static partial class DependencyInjectionExtensions
         services.TryAddTransient<DatabaseSearchService>();
         services.TryAddTransient<FileStorageService>();
         services.TryAddTransient<PackageService>();
-        services.TryAddTransient<V2UpstreamClient>();
-        services.TryAddTransient<V3UpstreamClient>();
         services.TryAddTransient<MultiFeedUpstreamClient>();
         services.TryAddTransient<DisabledUpstreamClient>();
         services.TryAddSingleton<NullStorageService>();
@@ -196,7 +195,7 @@ public static partial class DependencyInjectionExtensions
     {
         var options = provider.GetRequiredService<IOptions<MirrorOptions>>().Value;
         var httpClient = provider.GetRequiredService<HttpClient>();
-
+        
         var clients = new List<IUpstreamClient>();
 
         foreach (var source in options.Sources)
@@ -240,13 +239,6 @@ public static partial class DependencyInjectionExtensions
         if (!options.Value.Enabled)
             return provider.GetRequiredService<DisabledUpstreamClient>();
 
-        if (options.Value.HasMultipleSources)
-        {
-            return provider.GetRequiredService<MultiFeedUpstreamClient>();
-        }
-        else
-        {
-            return options.Value.Legacy ? provider.GetRequiredService<V2UpstreamClient>() : provider.GetRequiredService<V3UpstreamClient>();
-        }
+        return provider.GetRequiredService<MultiFeedUpstreamClient>();
     }
 }

--- a/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/BaGetter.Core/Extensions/DependencyInjectionExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -205,7 +204,11 @@ public static partial class DependencyInjectionExtensions
             if (source.Legacy)
             {
                 var logger = provider.GetRequiredService<ILogger<V2UpstreamClient>>();
-                var optionSnapshot = (IOptionsSnapshot<MirrorOptions>)provider.GetRequiredService<IOptions<MirrorOptions>>();
+
+                using var scope = provider.CreateScope();
+                var scopedProvider = scope.ServiceProvider;
+
+                var optionSnapshot = scopedProvider.GetRequiredService<IOptionsSnapshot<MirrorOptions>>();
                 client = new V2UpstreamClient(optionSnapshot, logger);
             }
             else

--- a/src/BaGetter.Core/Upstream/Clients/MultiFeedUpstreamClient.cs
+++ b/src/BaGetter.Core/Upstream/Clients/MultiFeedUpstreamClient.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Options;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BaGetter.Core;
+internal class MultiFeedUpstreamClient : IUpstreamClient
+{
+    private readonly List<IUpstreamClient> _clients;
+
+    public MultiFeedUpstreamClient(IOptionsSnapshot<MirrorOptions> options, List<IUpstreamClient> clients)
+    {
+        ArgumentNullException.ThrowIfNull(clients);
+
+        if (!options.Value.HasMultipleSources && clients.Count == 0)
+        {
+            throw new ArgumentException("At least one upstream client must be provided.");
+        }
+
+        _clients = clients;
+    }
+
+    public async Task<IReadOnlyList<NuGetVersion>> ListPackageVersionsAsync(string id, CancellationToken cancellationToken)
+    {
+        var versions = new List<NuGetVersion>();
+
+        foreach (var client in _clients)
+        {
+            var clientVersions = await client.ListPackageVersionsAsync(id, cancellationToken);
+            versions.AddRange(clientVersions);
+        }
+
+        return versions.DistinctBy(c => c.OriginalVersion).ToList();
+    }
+
+    public async Task<IReadOnlyList<Package>> ListPackagesAsync(string id, CancellationToken cancellationToken)
+    {
+        var packages = new List<Package>();
+
+        foreach (var client in _clients)
+        {
+            var clientPackages = await client.ListPackagesAsync(id, cancellationToken);
+            packages.AddRange(clientPackages);
+        }
+
+        return packages.DistinctBy(p => p.Version).ToList();
+    }
+
+    public async Task<Stream> DownloadPackageOrNullAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+    {
+        foreach (var client in _clients)
+        {
+            var packageStream = await client.DownloadPackageOrNullAsync(id, version, cancellationToken);
+            if (packageStream != null)
+            {
+                return packageStream;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/BaGetter.Core/Upstream/Clients/MultiFeedUpstreamClient.cs
+++ b/src/BaGetter.Core/Upstream/Clients/MultiFeedUpstreamClient.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.Extensions.Options;
 using NuGet.Versioning;
 using System;
@@ -13,13 +14,13 @@ internal class MultiFeedUpstreamClient : IUpstreamClient
 {
     private readonly List<IUpstreamClient> _clients;
 
-    public MultiFeedUpstreamClient(IOptionsSnapshot<MirrorOptions> options, List<IUpstreamClient> clients)
+    public MultiFeedUpstreamClient(List<IUpstreamClient> clients)
     {
         ArgumentNullException.ThrowIfNull(clients);
 
-        if (!options.Value.HasMultipleSources && clients.Count == 0)
+        if (clients is null || clients.Count == 0)
         {
-            throw new ArgumentException("At least one upstream client must be provided.");
+            throw new ArgumentException("No mirror package source provided");
         }
 
         _clients = clients;

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -25,7 +25,7 @@
     // "Legacy": true,
     "PackageSource": "https://api.nuget.org/v3/index.json",
 
-    // Uncomment to use multiple mirror sources
+    // Uncomment to use multiple mirror sources, if PackageSource it will be appended to the list
     //"Sources": [
     //  {
     //    "PackageSource": "https://api.nuget.org/v3/index.json",

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -19,11 +19,19 @@
   },
 
   "Mirror": {
-    "Enabled": false,
+    "Enabled": true,
 
     // Uncomment this to use the NuGet v2 protocol
-    //"Legacy": true,
-    "PackageSource": "https://api.nuget.org/v3/index.json"
+    // "Legacy": true,
+    "PackageSource": "https://api.nuget.org/v3/index.json",
+
+    // Uncomment to use multiple mirror sources
+    //"Sources": [
+    //  {
+    //    "PackageSource": "https://api.nuget.org/v3/index.json",
+    //    "Legacy": false
+    //  }
+    //]
   },
 
   // Uncomment this to configure BaGetter to listen to port 8080.

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -19,7 +19,7 @@
   },
 
   "Mirror": {
-    "Enabled": true,
+    "Enabled": false,
 
     // Uncomment this to use the NuGet v2 protocol
     // "Legacy": true,

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -22,7 +22,7 @@
     "Enabled": false,
 
     // Uncomment this to use the NuGet v2 protocol
-    // "Legacy": true,
+    //"Legacy": true,
     "PackageSource": "https://api.nuget.org/v3/index.json",
 
     // Uncomment to use multiple mirror sources if PackageSource is set, it will be appended to the list

--- a/src/BaGetter/appsettings.json
+++ b/src/BaGetter/appsettings.json
@@ -25,7 +25,7 @@
     // "Legacy": true,
     "PackageSource": "https://api.nuget.org/v3/index.json",
 
-    // Uncomment to use multiple mirror sources, if PackageSource it will be appended to the list
+    // Uncomment to use multiple mirror sources if PackageSource is set, it will be appended to the list
     //"Sources": [
     //  {
     //    "PackageSource": "https://api.nuget.org/v3/index.json",


### PR DESCRIPTION
Added possibility to specify multiple PackageSources in the appsettings.

 * Feeds will be searched in the order of the the specified Sources list
 * It's backwards compatible, meaning you wouldn't have to change the appsettings when updating and not wanting to use multiple mirrorfeeds
 * Even when using the "old" config meaning setting only the PackageSource property it will convert into a "MultiFeedUpstreamClient" in which the IUpstreamClients are contained 


 